### PR TITLE
Handle old permalink structure

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -30,6 +30,8 @@ module.exports = function(eleventyConfig) {
 
   eleventyConfig.addFilter('latestEpisode', episodes => episodes.find(episode => episode.isLatest));
 
+  eleventyConfig.addFilter('wordpressPermalink', title => title.toLowerCase().replace(/\s/gi, '-'));
+
   return {
 		templateFormats: ['md', 'njk', 'html'],
 		markdownTemplateEngine: 'njk',

--- a/_includes/episode.njk
+++ b/_includes/episode.njk
@@ -1,0 +1,34 @@
+---
+layout: layouts/base.njk
+---
+
+<main class="episode">
+  <div class="wrapper">
+    <section class="episode-header">
+      <div class="wrapper--small">
+        <h2 class="title-2 episode-header__title">{{ episode.title }}</h2>
+        <span class="episodes-item-details">
+          <time>{{ episode.publicationDate | formatDate }}</time>
+          <span>·</span> 
+          <span>{{ episode.duration | formatDuration }}</span>
+        </span>
+        <p class="body-big text-gray">{{ episode.summary }}</p>
+      </div>
+    </section>
+    {% include "components/podlove-web-player.njk" %}
+    <section class="episode-content">
+      <div class="episode-main">
+        <div class="episode-shownotes">
+          <div class="episode-shownotes-card">
+            <h3 class="title-2 episode-shownotes-card__title">Shownotes</h3>
+            {{ episode.content | safe }}
+          </div>
+        </div>
+      </div>
+      <aside class="episode-sidebar">
+        {% include "components/hosts.njk" %}
+        {% include "components/subscribe-box.njk" %}
+      </aside>
+    </section>
+  </div>
+</main>

--- a/episode-old-permalink.njk
+++ b/episode-old-permalink.njk
@@ -4,7 +4,7 @@ pagination:
     data: episodes
     size: 1
     alias: episode
-permalink: "episoden/{{ episode.number }}/"
+permalink: "{{ episode.title | wordpressPermalink }}/"
 eleventyComputed:
   title: "{{ episode.title }}"
   podlovePlayerEpisode: "{{ episode | dump | safe }}"


### PR DESCRIPTION
Netlify redirects aren't smart enough to handle this and HTML redirects suck so this just renders the page under the old permalink (e.g. `/sn001-homescreens` instead of `/episoden/1`).